### PR TITLE
player: fix typo in titlebar

### DIFF
--- a/examples/multimediawidgets/player/main.cpp
+++ b/examples/multimediawidgets/player/main.cpp
@@ -49,7 +49,7 @@ int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
 
-    QCoreApplication::setApplicationName("Rockhip Player");
+    QCoreApplication::setApplicationName("Rockchip Player");
     QCoreApplication::setOrganizationName("Rockchip");
     QCoreApplication::setApplicationVersion(QT_VERSION_STR);
     QCommandLineParser parser;


### PR DESCRIPTION
Fixes a minor typo resulting the titlebar of player showing Rockhip player.